### PR TITLE
Update Filebeat download URL

### DIFF
--- a/automatic/filebeat/update.ps1
+++ b/automatic/filebeat/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$url = 'https://www.elastic.co/downloads/past-releases/filebeat'
+$url = 'https://www.elastic.co/downloads/beats/filebeat'
 $packageName = 'filebeat'
 
 function global:au_SearchReplace {


### PR DESCRIPTION
The Filebeat package is currently a few versions behind (7.12.0 instead of 7.13.1). That seems to be because the URL checked by the update script now returns a 404 error, so the update check always fails.

I've changed the URL to the current Filebeat download page. Not sure if the old one looked any different, but other Beat update scripts ([such as Winlogbeat](https://github.com/palethorper/chocolatey-packages/blob/2f98be1ea9bc0c090427ec261c126782e74e1523/automatic/winlogbeat/update.ps1#L3)) seem to have also been switched away from the `past-releases` pages.